### PR TITLE
improve URL regex

### DIFF
--- a/src/CCLabelBMFontExt.h
+++ b/src/CCLabelBMFontExt.h
@@ -172,8 +172,7 @@ class CCLabelBMFontExt : public CCMenu
         float maxX;
 
         bool isUrl(std::string str) {
-            //std::regex pattern("^(https?://)?[\\w\\-]+(\\.[\\w\\-]+)+[/\\w\\-\\.,@?^=%&:/~\\+#]*");
-            std::regex pattern("^((http[s]?|ftp):\\/)?\\/?([^:\\/\\s]+)((\\/\\w+)*\\/)([\\w\\-\\.]+[^#?\\s]+)(.*)?(#[\\w\\-]+)?$");
+            std::regex pattern("^(https?:\\/\\/)?((?:[^\\/:@\\s]+\\.)+)((?:[a-z]{2,})|(?:xn--[a-z0-9\\-]{2,}))(?:\\/\\S*)?$");
     
             return std::regex_match(str, pattern);
         }


### PR DESCRIPTION
previous regex would fail on any URLs that did not have leading paths, eg. `https://example.com/` would fail, while `https://example.com/test` would not
i've rewritten the regex to hopefully match about most of what you'd see in a GD comment (so no support for `@` signs in URLs, no non-http/s protocols, etc) but still match short-form URLs such as `example.com`